### PR TITLE
Support for TENMA 72-2540 v5.8

### DIFF
--- a/koradctl/args.py
+++ b/koradctl/args.py
@@ -11,6 +11,7 @@ def get_arg_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('-I', '--interactive',                          dest='interactive',             action='store_true', default=False,          help='enable interactive mode')
     parser.add_argument('-t', '--test',                                 dest='test',                    action='store_true', default=False,          help='run the tests and quit')
+    parser.add_argument('-d', '--identify',                             dest='identify',                action='store_true', default=False,          help='show the identity and quit')
 
     parser.add_argument(      '--ocp',          type=human_bool,        dest='over_current_protection', action='store',      default=None,           help='set the over current protection')
     parser.add_argument(      '--ovp',          type=human_bool,        dest='over_voltage_protection', action='store',      default=None,           help='set the over current protection')

--- a/koradctl/cli.py
+++ b/koradctl/cli.py
@@ -27,6 +27,13 @@ class Cli:
     def run(self):
         if self.args.test:
             self.run_tests()
+        elif self.args.identify:
+            print(f"Device identity: {self.psu.get_identity()}")
+
+            serial = self.psu.get_serial_number()
+            if serial is not None:
+                print(f"Serial Number: {serial}")
+
         elif self.args.interactive:
             self.run_interactive()
         else:

--- a/koradctl/psu.py
+++ b/koradctl/psu.py
@@ -1,3 +1,6 @@
+
+import re
+
 from time import sleep
 from datetime import datetime
 from typing import Union, Tuple
@@ -17,8 +20,13 @@ from koradctl.pretty import Status, Reading
 # we impose a gap of at least ~50ms between commands
 INTER_COMMAND_DELAY = 0.05
 
+# Firmwares that have been tested with this library.
+#
+# Before adding a new firmware here, run `test.py` against it to make sure that it is
+# fully supported.
 tested_firmware = [
     'TENMA 72-2540 V2.1',
+    re.compile(r'^TENMA 72-2540 V5.8 SN:(\d+)$'),
 ]
 
 class PowerSupply:
@@ -96,7 +104,17 @@ class PowerSupply:
         list
         """
         identity = self.get_identity()
-        return identity in tested_firmware
+        for version in tested_firmware:
+            if isinstance(version, re.Pattern):
+                if version.fullmatch(identity):
+                    return True
+            elif isinstance(version, str):
+                if version == identity:
+                    return True
+            else:
+                raise ValueError("Unsupported type in 'tested_firmware'.")
+
+        return False
 
 
     def get_status(self) -> Status:


### PR DESCRIPTION
Closes #1

Adds support for devices with more complex responses to `get_identity`. 

- Make the logic for `is_tested` use regular expressions to parse the response to `get_identity`
- Add `get_serial_number` to return the serial number (if it could be captured)
- Add `--identify` flag to cli to return the serial number

This has been tested on the power supply I have. It _should_ work on others, but I cannot test them. 