### PR TITLE
Add py.typed & type check package

### DIFF
--- a/koradctl/types.py
+++ b/koradctl/types.py
@@ -1,10 +1,10 @@
-from typing import Union, List, Tuple
+from typing import Any, Union, List, Tuple
 
 true_values = [ '1', 'on', 'yes' ]
 false_values = [ '0', 'off', 'no' ]
 toggle_values = [ 't', 'toggle' ]
 
-def from_options(arg: str, options: List[Tuple[List[str], bool]]):
+def from_options(arg: str, options: List[Tuple[List[str], Any]]):
     for values, ret in options:
         if arg in values:
             return ret

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyserial==3.4
+pyserial~=3.0

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     url='https://github.com/attie/koradctl',
     license='BSD-3-Clause',
     packages=[ 'koradctl' ],
+    package_data={m.package_info['proj_name']: ["py.typed"]},
     install_requires=[
         'pyserial',
     ],


### PR DESCRIPTION
Update the package by 

- adding a `py.typed` file to signal to type checkers that the package contains type annotations;
- relaxing the version range of pySerial to allow versions greater than 3.4

Doing this showed some issues with the current type annotation, so I went ahead and updated them. They mostly boil down to 

- replace `collections.namedtuple` with `typing.NamedTuple`
- add `None` checks to the result of `issue_command`

The individual commits have more details. 